### PR TITLE
Fix links between versions of the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To create a snapshot of a version:
 ```text
 **Latest Version:**
 
-- Specification: [https://identity.foundation/didwebvh/](../)
+- Specification: [https://identity.foundation/didwebvh/](/)
 - Repository: [https://github.com/decentralized-identity/didwebvh](https://github.com/decentralized-identity/didwebvh)
 
 ```

--- a/spec-v0.3/header.md
+++ b/spec-v0.3/header.md
@@ -9,7 +9,7 @@ This version of the specification was released at the time the OLD name for the 
 
 **Latest Version:**
 
-- Specification: [https://identity.foundation/didwebvh/](../)
+- Specification: [https://identity.foundation/didwebvh/](/)
 - Repository: [https://github.com/decentralized-identity/didwebvh](https://github.com/decentralized-identity/didwebvh)
 
 **Editors:**

--- a/spec-v0.4/header.md
+++ b/spec-v0.4/header.md
@@ -7,7 +7,7 @@ Trust DID Web - `did:tdw` - v0.4
 
 This version of the specification was released at the time the OLD name for the DID Method was in use. The DID Method hame has since changed to `did:webvh` ("`did:web` + Verifiable History").
 
-**Next Specification:** [Draft](./next)
+**Next Specification:** [Draft](/next)
 
 :::warning
 
@@ -21,7 +21,7 @@ the DID Method from `did:tdw` to `did:webvh`.
   [https://github.com/decentralized-identity/didwebvh/tree/main/spec-v0.4](https://github.com/decentralized-identity/didwebvh/tree/main/spec-v0.4)
 
 **Previous Drafts:**
-- [v0.3](../v0.3)
+- [v0.3](/v0.3)
 
 **Information Site:**
   [https://didtdw.org/](https://didtdw.org/)

--- a/spec/header.md
+++ b/spec/header.md
@@ -16,7 +16,7 @@ The updates in process are:
 - Changing how and where witness proofs are managed.
 - Renaming the DID Method.
 
-**Current Specification:**- [v0.4](../)
+**Current Specification:**- [v0.4](/)
 
 **Specification Version:** To Be Defined (see [Changelog](#didwebvh-version-changelog))
 
@@ -24,7 +24,7 @@ The updates in process are:
   [https://github.com/decentralized-identity/didwebvh](https://github.com/decentralized-identity/didwebvh)
 
 **Previous Drafts:**
-- [v0.3](./v0.3)
+- [v0.3](/v0.3)
 
 **Information Site:**
   [https://didwebvh.info/](https://didwebvh.info/)


### PR DESCRIPTION
Fixes #156.  Changes all the relative links to be absolute from the root of the site.

Signed-off-by: Stephen Curran <swcurran@gmail.com>
