### PR TITLE
Correct DID URL examples and description in v0.4, v0.5 and Editors Draft versions

### DIFF
--- a/spec-v0.4/specification.md
+++ b/spec-v0.4/specification.md
@@ -1003,30 +1003,25 @@ The risk of publishing the `did:web` in parallel with the `did:tdw` is that the
 added security and convenience of using `did:tdw` are lost.
 
 ### DID URL Resolution
-
 The `did:tdw` DID Method embraces the power and usefulness of DID URLs, along
 with the semantic simplicity of using them with a web-based DID method.
 Specifically, a `did:tdw` implementation **MUST**:
 
 - Resolve the `/whois` DID URL path using a [[spec:LINKED-VP]] service, whether
-  or not it exists in the `did:tdw` [[ref: DIDDoc]], returning a [[ref: Verifiable
-  Presentation]], if published by the [[ref: DID Controller]], found at the same
-  path as the `did.jsonl` file, using the `/whois.vp` filename component, and
-  the `application/vp' media type, as per the [IANA Verifiable Presentation
+  or not it exists in the `did:tdw` [[ref: DIDDoc]], returning a [[ref:
+  Verifiable Presentation]], if published by the [[ref: DID Controller]], found
+  at the same path as the `did.jsonl` file (excluding the `.well-known` folder,
+  if present), using the `/whois.vp` filename component, and the
+  `application/vp' media type, as per the [IANA Verifiable Presentation
   Assignment](https://www.iana.org/assignments/media-types/application/vp).
-  - For example, `did:tdw:{SCID}.example.com/whois` returns the [[ref: verifiable
-    presentation]] from `https://{SCID}.example.com/.well-known/whois.vp`.
+  - For example, `did:tdw:{SCID}:example.com/whois` returns the
+    [[ref: verifiable presentation]] from `https://example.com/whois.vp`.
 - Resolve any `did:tdw` DID URL using a [[spec:DID-CORE]] `relativeRef` DID
   [[ref: parameter]], whether or not a supporting service exists in the `did:tdw` [[ref: DIDDoc]],
   returning the file found at web location corresponding to the DID-to-HTTPS
-  transformation.
-  - For example, resolving `did:tdw:example.com:{SCID}/governance/issuers.json` returns
-    the file `https://example.com/{SCID}/governance/issuer.json`
-  - When the `{SCID}` is placed as a subdomain, the file is found relative to
-    that subdomain, and not in the `.well-known` folder where the `did.jsonl`
-    file is found. For example, resolving
-    `did:tdw:{SCID}.example.com/governance/issuers.json` returns the file
-    `https://{SCID}.example.com/governance/issuer.json`.
+  transformation (excluding the `.well-known` folder, if present).
+  - For example, resolving `did:{SCID}:tdw:example.com/governance/issuers.json` returns
+    the file `https://example.com/governance/issuer.json`
 
 In both cases, a [[ref: DID Controller]] **MAY** define services in the DIDDoc
 that override the default services that **MUST** be resolved by the `did:tdw`

--- a/spec-v0.5/specification.md
+++ b/spec-v0.5/specification.md
@@ -1160,30 +1160,25 @@ The risk of publishing the `did:web` in parallel with the `did:webvh` is that th
 added security and convenience of using `did:webvh` are lost.
 
 ### DID URL Resolution
-
 The `did:webvh` DID Method embraces the power and usefulness of DID URLs, along
 with the semantic simplicity of using them with a web-based DID method.
 Specifically, a `did:webvh` implementation **MUST**:
 
 - Resolve the `/whois` DID URL path using a [[spec:LINKED-VP]] service, whether
-  or not it exists in the `did:webvh` [[ref: DIDDoc]], returning a
-  [[ref: Verifiable Presentation]], if published by the [[ref: DID Controller]],
-  found at the same path as the `did.jsonl` file, using the `/whois.vp` filename
-  component, and the `application/vp' media type, as per the
-  [IANA Verifiable Presentation Assignment](https://www.iana.org/assignments/media-types/application/vp).
-  - For example, `did:webvh:{SCID}.example.com/whois` returns the
-    [[ref: verifiable presentation]] from `https://{SCID}.example.com/.well-known/whois.vp`.
+  or not it exists in the `did:webvh` [[ref: DIDDoc]], returning a [[ref:
+  Verifiable Presentation]], if published by the [[ref: DID Controller]], found
+  at the same path as the `did.jsonl` file (excluding the `.well-known` folder,
+  if present), using the `/whois.vp` filename component, and the
+  `application/vp' media type, as per the [IANA Verifiable Presentation
+  Assignment](https://www.iana.org/assignments/media-types/application/vp).
+  - For example, `did:webvh:{SCID}:example.com/whois` returns the
+    [[ref: verifiable presentation]] from `https://example.com/whois.vp`.
 - Resolve any `did:webvh` DID URL using a [[spec:DID-CORE]] `relativeRef` DID
   [[ref: parameter]], whether or not a supporting service exists in the `did:webvh` [[ref: DIDDoc]],
   returning the file found at web location corresponding to the DID-to-HTTPS
-  transformation.
-  - For example, resolving `did:webvh:example.com:{SCID}/governance/issuers.json` returns
-    the file `https://example.com/{SCID}/governance/issuer.json`
-  - When the `{SCID}` is placed as a subdomain, the file is found relative to
-    that subdomain, and not in the `.well-known` folder where the `did.jsonl`
-    file is found. For example, resolving
-    `did:webvh:{SCID}.example.com/governance/issuers.json` returns the file
-    `https://{SCID}.example.com/governance/issuer.json`.
+  transformation (excluding the `.well-known` folder, if present).
+  - For example, resolving `did:{SCID}:webvh:example.com/governance/issuers.json` returns
+    the file `https://example.com/governance/issuer.json`
 
 In both cases, a [[ref: DID Controller]] **MAY** define services in the DIDDoc
 that override the default services that **MUST** be resolved by the `did:webvh`

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -1166,24 +1166,20 @@ with the semantic simplicity of using them with a web-based DID method.
 Specifically, a `did:webvh` implementation **MUST**:
 
 - Resolve the `/whois` DID URL path using a [[spec:LINKED-VP]] service, whether
-  or not it exists in the `did:webvh` [[ref: DIDDoc]], returning a
-  [[ref: Verifiable Presentation]], if published by the [[ref: DID Controller]],
-  found at the same path as the `did.jsonl` file, using the `/whois.vp` filename
-  component, and the `application/vp' media type, as per the
-  [IANA Verifiable Presentation Assignment](https://www.iana.org/assignments/media-types/application/vp).
-  - For example, `did:webvh:{SCID}.example.com/whois` returns the
-    [[ref: verifiable presentation]] from `https://{SCID}.example.com/.well-known/whois.vp`.
+  or not it exists in the `did:webvh` [[ref: DIDDoc]], returning a [[ref:
+  Verifiable Presentation]], if published by the [[ref: DID Controller]], found
+  at the same path as the `did.jsonl` file (excluding the `.well-known` folder,
+  if present), using the `/whois.vp` filename component, and the
+  `application/vp' media type, as per the [IANA Verifiable Presentation
+  Assignment](https://www.iana.org/assignments/media-types/application/vp).
+  - For example, `did:webvh:{SCID}:example.com/whois` returns the
+    [[ref: verifiable presentation]] from `https://example.com/whois.vp`.
 - Resolve any `did:webvh` DID URL using a [[spec:DID-CORE]] `relativeRef` DID
   [[ref: parameter]], whether or not a supporting service exists in the `did:webvh` [[ref: DIDDoc]],
   returning the file found at web location corresponding to the DID-to-HTTPS
-  transformation.
-  - For example, resolving `did:webvh:example.com:{SCID}/governance/issuers.json` returns
-    the file `https://example.com/{SCID}/governance/issuer.json`
-  - When the `{SCID}` is placed as a subdomain, the file is found relative to
-    that subdomain, and not in the `.well-known` folder where the `did.jsonl`
-    file is found. For example, resolving
-    `did:webvh:{SCID}.example.com/governance/issuers.json` returns the file
-    `https://{SCID}.example.com/governance/issuer.json`.
+  transformation (excluding the `.well-known` folder, if present).
+  - For example, resolving `did:{SCID}:webvh:example.com/governance/issuers.json` returns
+    the file `https://example.com/governance/issuer.json`
 
 In both cases, a [[ref: DID Controller]] **MAY** define services in the DIDDoc
 that override the default services that **MUST** be resolved by the `did:webvh`


### PR DESCRIPTION
This PR does two things that are corrections to mistakes in the v0.4/v0.5/Editor's Draft versions of the spec.

The first correction is that in the `DID URL Resolution` section, the example DIDs were not updated to reflect the change to the location of the SCID from v0.3. This was a mistake in the update of the specification, so this is a fix.

The second correction is that there is a contradiction between the `DID URL Resolution` introduction text and the `whois LinkedVP Section`. In the first, the text says the `whois.vp` file **is** to be placed in the `.well-known` folder if that is where the `did.jsonl` file is placed, while the second example says the file **is NOT** to be placed in the `.well-known` folder. The intention of the Editors was the latter, so the text in the DID URL section was corrected.



Signed-off-by: Stephen Curran <swcurran@gmail.com>
