### PR TITLE
Update spec to add a reference to DNS requirements when moving a DID

### DIFF
--- a/spec/specification.md
+++ b/spec/specification.md
@@ -884,6 +884,7 @@ DIDDoc to one that resolves to a different HTTPS URL if the following conditions
   [DID Method Parameters](#didwebvh-did-method-parameters) section.
 - The [[ref: SCID]] **MUST** be the same in the original and renamed DID.
 - The [[ref: DIDDoc]] **MUST** contain the prior DID string as an `alsoKnownAs` entry.
+- [[ref: DID Controllers]] **SHOULD** account for any DNS requirements in making domain changes that impact a `did:webvh` DID being moved, such as those outlined in [[spec:1034]] (“Domain Names - Concepts and Facilities”), and [[spec:rfc1035]] (“Domain Names Implementation and Specification”).
 
 #### Pre-Rotation Key Hash Generation and Verification
 


### PR DESCRIPTION
Addresses the second proposal in issue #173 -- adding the concept of a "lock" on a `did:webvh` that prevents moving the DID while the lock is in place. At the [2025.02.27 Meeting](https://hackmd.io/k4cIK9vQSlaeg2pdHE51IQ) we agreed not to add that feature, but just to put a comment into the spec about the need to follow DNS Domain requirements when moving a DID. This PR adds that, referencing the relevant IETF specs.

I think this covers what was asked for at that meeting -- feedback welcome.
