### PR TITLE
Add deleting the DID Log to the Deactivate DID section of the spec

### DIFF
--- a/spec/specification.md
+++ b/spec/specification.md
@@ -556,6 +556,8 @@ property key:value pair `"deactivated": true` **MUST** return in the [[ref:
 DIDDoc]] Metadata the property key:value `"deactivated": true`, as per the
 [[spec:DID-RESOLUTION]] specification.
 
+A [[ref: DID Controller]] can “deactivate” a DID by removing the published [[ref: DID Log]] and associated files and resources. Once removed, attempts to retrieve the [[ref: DID Log]] will result in an `HTTP 404 Not Found` (or an equivalent error status when resolving the DID). [[ref: Watchers]] monitoring a removed DID SHOULD continue to cache the last known valid state of the DID indefinitely so that their clients can still resolve and reference it, even after the [[ref: DID Log]] has been deleted.
+
 ### DID Method Processes
 
 The [DID Method Operations](#did-method-operations) reference several processes


### PR DESCRIPTION
Addresses an issue that came up in issue #161 about referencing that a DID Controller can just delete the DID Log and thus, deactive the DID but making it inaccessible. Included in the note that watchers should continue to host and return the DID information indefintely, enabling watcher clients to retrieve the DID after deletion.

