### PR TITLE
Remove the reference to the High Assurance DIDs with DNS

### DIFF
--- a/spec/abstract.md
+++ b/spec/abstract.md
@@ -23,7 +23,6 @@ limitations as a long-lasting DID. `did:webvh` features include:
   control of a DID in cases where an active private key is compromised.
 - An optional mechanism for having collaborating [[ref: witnesses]]
   that approve of updates to the DID by a [[ref: DID Controller]] before publication.
-- Supports the same [High Assurance DIDs with DNS] mechanism.
 - DID URL path handling that defaults (but can be overridden) to automatically
   resolving `<did>/path/to/file` by using a comparable DID-to-HTTPS translation
   as for the [[ref: DIDDoc]].
@@ -33,8 +32,6 @@ limitations as a long-lasting DID. `did:webvh` features include:
   `credentialSubject`, signed by the DID. It draws inspiration from the
   traditional WHOIS protocol [[spec:rfc3912]], offering an easy-to-use,
   decentralized, trust registry.
-
-[High Assurance DIDs with DNS]: https://datatracker.ietf.org/doc/draft-carter-high-assurance-dids-with-dns/
 
 Combined, the additional features enable greater trust, security and verifiability without
 compromising the simplicity of `did:web`.


### PR DESCRIPTION
Remove the reference to High Assurance DIDs with DNS spec from the overview, as we don't use it in the specification. In the information site ([https://didwebvh.info](https://didwebvh.info) we talk about how the spec can be used, but there is nothin the spec itself that uses that specification.

We made add in a way to link a DID to DNS records, but its not clear how to leverage the spec we are removing or how to define a did:webvh specific way.
