### PR TITLE
Extend Security and Privacy Considerations section

### DIFF
--- a/spec/security_and_privacy.md
+++ b/spec/security_and_privacy.md
@@ -4,7 +4,7 @@
 
 #### DNS Security Considerations
 
-Implementers must secure DNS resolution to protect against attacks like Man in
+Implementers **MUST** secure DNS resolution to protect against attacks like Man in
 the Middle, following the detailed guidance in the [did:web
 specification](https://w3c-ccg.github.io/did-method-web/#dns-considerations).
 The use of DNSSEC [[spec:RFC4033]], [[spec:RFC4034]], [[spec:RFC4035]] is
@@ -13,7 +13,7 @@ essential to prevent spoofing and ensure authenticity of DNS records.
 #### DNS Privacy Considerations
 
 Resolving a `did:webvh` identifier can expose users to tracking by DNS providers
-and web servers. To mitigate this risk, it's recommended to use privacy-enhancing
+and web servers. To mitigate this risk, it's **RECOMMENDED** to use privacy-enhancing
 technologies such as VPNs, TOR, or trusted universal resolver services, in line
 with strategies outlined in the [did:web
 specification](https://w3c-ccg.github.io/did-method-web/#dns-considerations)
@@ -25,8 +25,8 @@ for DNS privacy.
 
 For in-transit security, the guidance provided in the [did:web
 specification](https://w3c-ccg.github.io/did-method-web/#in-transit-security)
-regarding the encryption of traffic between the server and client should be
-followed.
+regarding the encryption of traffic between the server and client **SHOULD** be
+followed. Ecosystem implementors **SHOULD** follow the same guidance for [[ref: watchers]] and [[ref: witnesses]] implementations.
 
 ### International Domain Names
 
@@ -40,3 +40,21 @@ followed.
 To support scenarios where DID resolution is performed by client applications running in a web browser, the file served for the [[ref: DID Log]] needs to be accessible by any origin. To enable this, the [[ref: DID Log]] HTTP response MUST include the following header:
 
 `Access-Control-Allow-Origin: *`
+
+### Publishing parallel `did:web`
+
+`did:webvh` implementers that consider [publishing parallel `did:web` DID](#publishing-a-parallel-didweb-did) **SHOULD** evaluate
+security impact from losing added security properties of `did:webvh` 
+and refer to [did:web Security and Privacy Considerations](https://w3c-ccg.github.io/did-method-web/#dns-considerations) for additional guidance.
+
+### Right to Erasure ([GDPR Art. 17](https://gdpr-info.eu/art-17-gdpr/))
+
+While it's possible for [[ref: DID Controller]] to delete published data as described in [Deactivate (Revoke) operation](#deactivate-revoke),
+it's **RECOMMENDED** for monitoring [[ref: watchers]] to cache last known state indefinitely. 
+This means that ability and specific process of complete data erasure depends on [[ref: watchers]] behavior
+and **SHOULD** be defined by governance of ecosystem.
+
+### Post Quantum Attacks
+
+`did:webvh` [[ref: Key Pre-Rotation]] approach provides enough flexibility for "post-quantum safety".
+For guidance on post-quantum attacks mitigation, implementors **SHOULD** refer to [corresponding Implementation Guide section](https://didwebvh.info/latest/implementers-guide/prerotation-keys/#post-quantum-attacks).


### PR DESCRIPTION
- Added new `did:webvh`-specific considerations
- Updated `In-transit Security` point to mention `watchers` and `witnesses`
- Misc. cleanup

My thoughts and potential points to discuss

- General approach for "Security and Privacy" - non-normative with `did:webvh`-specific points seems to be good enough
  - Other option would be to describe privacy/security properties based on RFCs (for example, similar to how it's done in [DID Indy Method spec](https://hyperledger.github.io/indy-did-method/#privacy-considerations)). However, `did:webvh` do not describe or enforce all related implementation options, so sticking to RFC-based list of properties may not provide much value
- `did:webvh` spec mentions some interesting use cases that, however, not part of the spec. Good example is [watchers network to independently monitor DID updates via consensus](https://github.com/decentralized-identity/didwebvh/blob/main/spec/specification.md?plain=1#L1036), being also a good candidate for providing additional guidance as "Security Consideration". But, as these are out of scope for the spec, we should leave them out of "Security and Privacy" as well