### PR TITLE
Update implementations list in spec and add test suite

### DIFF
--- a/spec-v1.0/header.md
+++ b/spec-v1.0/header.md
@@ -40,19 +40,26 @@ The current [Editor's Draft](../next) of the specification will be maintained in
 ~ [File a bug](https://github.com/decentralized-identity/didwebvh/issues)
 ~ [Commit history](https://github.com/decentralized-identity/didwebvh/commits/main)
 
+**Interoperability Test Suite:**
+~ [Test Suite](https://github.com/decentralized-identity/didwebvh-test-suite)
+
 **Implementations:**
 ~ [TypeScript]
 ~ [Python]
-~ [Go] - supports v03
-~ [Rust] - work in progress
+~ [Rust]
+~ [Java]
+~ [Java EECC]
+~ [Dart]
 ~ [did:webvh Server]
 ~ [did:webvh ACA-Py Plugin]
 
 [TypeScript]: https://github.com/decentralized-identity/trustdidweb-ts
 [Python]: https://github.com/decentralized-identity/trustdidweb-py
-[Go]: https://github.com/nuts-foundation/trustdidweb-go
 [Rust]: https://github.com/decentralized-identity/didwebvh-rs
-[did:webvh Server]: https://github.com/decentralized-identity/trustdidweb-server-py
-[did:webvh ACA-Py Plugin]: https://plugins.aca-py.org/latest/webvh/
+[Java]: https://github.com/decentralized-identity/didwebvh-java
+[Java EECC]: https://github.com/european-epc-competence-center/didwebvh
+[Dart]: https://github.com/decentralized-identity/didwebvh-dart
+[did:webvh Server]: https://github.com/decentralized-identity/didwebvh-server-py
+[did:webvh ACA-Py Plugin]: https://github.com/openwallet-foundation/acapy-plugins/tree/main/webvh
 
 ------------------------------------

--- a/spec/header.md
+++ b/spec/header.md
@@ -1,4 +1,4 @@
-The `did:webvh` DID Method<br>v1.0 / Editors Draft
+The `did:webvh` DID Method<br>v1.0
 ==================
 
 ![did:webvh Logo](https://raw.githubusercontent.com/decentralized-identity/didwebvh/refs/heads/main/didwebvh.jpg)
@@ -16,7 +16,7 @@ This **v1.0 - Editors Draft** is being maintained in sync with the v1.0 specific
 
 **Previous Versions:**
 
-- [v0.4](../v0.5)
+- [v0.5](../v0.5)
 - [v0.4](../v0.4)
 - [v0.3](../v0.3)
 
@@ -38,19 +38,26 @@ This **v1.0 - Editors Draft** is being maintained in sync with the v1.0 specific
 ~ [File a bug](https://github.com/decentralized-identity/didwebvh/issues)
 ~ [Commit history](https://github.com/decentralized-identity/didwebvh/commits/main)
 
+**Interoperability Test Suite:**
+~ [Test Suite](https://github.com/decentralized-identity/didwebvh-test-suite)
+
 **Implementations:**
 ~ [TypeScript]
 ~ [Python]
-~ [Go] - supports v03
-~ [Rust] - work in progress
+~ [Rust]
+~ [Java]
+~ [Java EECC]
+~ [Dart]
 ~ [did:webvh Server]
 ~ [did:webvh ACA-Py Plugin]
 
 [TypeScript]: https://github.com/decentralized-identity/trustdidweb-ts
 [Python]: https://github.com/decentralized-identity/trustdidweb-py
-[Go]: https://github.com/nuts-foundation/trustdidweb-go
 [Rust]: https://github.com/decentralized-identity/didwebvh-rs
-[did:webvh Server]: https://github.com/decentralized-identity/trustdidweb-server-py
-[did:webvh ACA-Py Plugin]: https://github.com/openwallet-foundation/acapy-plugins/pull/1377 
+[Java]: https://github.com/decentralized-identity/didwebvh-java
+[Java EECC]: https://github.com/european-epc-competence-center/didwebvh
+[Dart]: https://github.com/decentralized-identity/didwebvh-dart
+[did:webvh Server]: https://github.com/decentralized-identity/didwebvh-server-py
+[did:webvh ACA-Py Plugin]: https://github.com/openwallet-foundation/acapy-plugins/tree/main/webvh
 
 ------------------------------------


### PR DESCRIPTION
Update the implementations list with the current set, adding 2 Java impementations and Dart, removing the Go implementation, and adding the interop test suite in both the 1.0 and "next" version.

Fixed a typo in the editor's draft version.




Signed-off-by: Stephen Curran <swcurran@gmail.com>
